### PR TITLE
[FIX] Bullet-confusion fix

### DIFF
--- a/client/include/GameState.hpp
+++ b/client/include/GameState.hpp
@@ -166,6 +166,7 @@ namespace RType {
 
             // Player ships tracking (network entities → ECS entities)
             std::unordered_map<uint32_t, RType::ECS::Entity> m_networkEntityMap;
+            std::unordered_map<uint32_t, uint8_t> m_bulletFlagsMap; // Track bullet flags to detect type changes
             RType::ECS::Entity m_localPlayerEntity = RType::ECS::NULL_ENTITY; // Local player entity mirrored from server
 
             // Individual player ship sprites


### PR DESCRIPTION
The problem was that there was confusion with the flags and the id of the bullet, for example if an enemy shot a bullet with ID = 100 and flags = 10, the player may shoot and reuse the bullet with ID = 100 and flags = 0 beacuse the entity is still there.

To resolve that, we create an array with the entity Id as a key and the flags as second value to check if the flags has changed.
If it's true, we destroy the entity so it will recreate the bullet with the good id and flag